### PR TITLE
URL Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: erlang
 notifications:
-  webhooks: http://basho-engbot.herokuapp.com/travis?key=8c2550739c2f776d4b05d993aa032f0724fe5450
+  webhooks: https://basho-engbot.herokuapp.com/travis?key=8c2550739c2f776d4b05d993aa032f0724fe5450
   email: eng@basho.com
 otp_release:
   - R16B

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to provide a more traditional way to perform logging in an erlang application
 that plays nicely with traditional UNIX logging tools like logrotate and
 syslog.
 
-  [Travis-CI](http://travis-ci.org/basho/lager) :: ![Travis-CI](https://secure.travis-ci.org/basho/lager.png)
+  [Travis-CI](https://travis-ci.org/basho/lager) :: ![Travis-CI](https://secure.travis-ci.org/basho/lager.png)
 
 Features
 --------
@@ -189,7 +189,7 @@ for the backend:
 ]}.
 ```
 
-Included is `lager_default_formatter`.  This provides a generic, default formatting for log messages using a structure similar to Erlang's [iolist](http://learnyousomeerlang.com/buckets-of-sockets#io-lists) which we call "semi-iolist":
+Included is `lager_default_formatter`.  This provides a generic, default formatting for log messages using a structure similar to Erlang's [iolist](https://learnyousomeerlang.com/buckets-of-sockets#io-lists) which we call "semi-iolist":
 
 * Any traditional iolist elements in the configuration are printed verbatim.
 * Atoms in the configuration are treated as placeholders for lager metadata and extracted from the log message.

--- a/src/lager_format.erl
+++ b/src/lager_format.erl
@@ -7,7 +7,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
-%% retrieved online at http://www.erlang.org/.
+%% retrieved online at https://www.erlang.org/.
 %% 
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -7,7 +7,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
-%% retrieved online at http://www.erlang.org/.
+%% retrieved online at https://www.erlang.org/.
 %% 
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -22,7 +22,7 @@
 %%
 %% All functions in this module are covered by the Erlang/OTP source
 %% distribution's license, the Erlang Public License.  See
-%% http://www.erlang.org/ for full details.
+%% https://www.erlang.org/ for full details.
 
 -module(lager_stdlib).
 

--- a/src/lager_trunc_io.erl
+++ b/src/lager_trunc_io.erl
@@ -2,7 +2,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with your Erlang distribution. If not, it can be
-%% retrieved via the world wide web at http://www.erlang.org/.
+%% retrieved via the world wide web at https://www.erlang.org/.
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/sync_error_logger.erl
+++ b/test/sync_error_logger.erl
@@ -7,7 +7,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
-%% retrieved online at http://www.erlang.org/.
+%% retrieved online at https://www.erlang.org/.
 %% 
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://basho-engbot.herokuapp.com/travis?key=8c2550739c2f776d4b05d993aa032f0724fe5450 (404) with 1 occurrences migrated to:  
  https://basho-engbot.herokuapp.com/travis?key=8c2550739c2f776d4b05d993aa032f0724fe5450 ([https](https://basho-engbot.herokuapp.com/travis?key=8c2550739c2f776d4b05d993aa032f0724fe5450) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://learnyousomeerlang.com/buckets-of-sockets with 1 occurrences migrated to:  
  https://learnyousomeerlang.com/buckets-of-sockets ([https](https://learnyousomeerlang.com/buckets-of-sockets) result 200).
* http://travis-ci.org/basho/lager with 1 occurrences migrated to:  
  https://travis-ci.org/basho/lager ([https](https://travis-ci.org/basho/lager) result 200).
* http://www.erlang.org/ with 5 occurrences migrated to:  
  https://www.erlang.org/ ([https](https://www.erlang.org/) result 200).